### PR TITLE
fix ext-deps rule error

### DIFF
--- a/lib/rules/ext-deps.js
+++ b/lib/rules/ext-deps.js
@@ -34,7 +34,8 @@ module.exports = function(context) {
 	};
 	
 	var addReference = function(typeName) {
-		calls[calls.length - 1].references[classes.alternates[typeName] || typeName] = true;
+		var lastCall = calls[calls.length - 1];
+		if( lastCall ) lastCall.references[classes.alternates[typeName] || typeName] = true;
 	};
 	
 	var handleTypes = function(node, key, callback, options) {

--- a/lib/rules/ext-deps.js
+++ b/lib/rules/ext-deps.js
@@ -34,8 +34,12 @@ module.exports = function(context) {
 	};
 	
 	var addReference = function(typeName) {
-		var lastCall = calls[calls.length - 1];
-		if( lastCall ) lastCall.references[classes.alternates[typeName] || typeName] = true;
+	        var lastCall = calls[calls.length - 1];
+	        var referenceName = classes.alternates[typeName] || typeName;
+	
+	        if( referenceName.indexOf("Ext.") !== 0 ){
+	            if( lastCall ) lastCall.references[ referenceName ] = true;
+	        }
 	};
 	
 	var handleTypes = function(node, key, callback, options) {


### PR DESCRIPTION
./node_modules/eslint-plugin-extjs/lib/rules/ext-deps.js:37
calls[calls.length - 1].references[classes.alternates[typeName] || typeName]
^
TypeError: Cannot read property 'references' of undefined
